### PR TITLE
feat(be): User Repository / CustomerAddress / CustomerProfile 엔티티 구현

### DIFF
--- a/backend/src/main/java/com/deliveranything/domain/delivery/entity/Delivery.java
+++ b/backend/src/main/java/com/deliveranything/domain/delivery/entity/Delivery.java
@@ -2,6 +2,8 @@ package com.deliveranything.domain.delivery.entity;
 
 
 import com.deliveranything.domain.delivery.enums.DeliveryStatus;
+import com.deliveranything.domain.reviews.entity.Review;
+import com.deliveranything.domain.user.entity.profile.CustomerProfile;
 import com.deliveranything.global.entity.BaseEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -49,17 +51,17 @@ public class Delivery extends BaseEntity {
   @Column(name = "delivery_charge")
   private Integer charge;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "store_id")
-  private Store store;
+//  @ManyToOne(fetch = FetchType.LAZY)
+//  @JoinColumn(name = "store_id")
+//  private Store store;
 
   @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
   @JoinColumn(name = "review_id")
   private Review review;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "rider_profile_id")
-  private RiderProfile rider;
+//  @ManyToOne(fetch = FetchType.LAZY)
+//  @JoinColumn(name = "rider_profile_id")
+//  private RiderProfile rider;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "customer_profile_id")

--- a/backend/src/main/java/com/deliveranything/domain/user/entity/User.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/entity/User.java
@@ -1,12 +1,16 @@
 package com.deliveranything.domain.user.entity;
 
+import com.deliveranything.domain.user.entity.profile.CustomerProfile;
 import com.deliveranything.domain.user.enums.ProfileType;
 import com.deliveranything.domain.user.enums.SocialProvider;
 import com.deliveranything.global.entity.BaseEntity;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -64,6 +68,10 @@ public class User extends BaseEntity {
   @Column(name = "last_login_at")
   private LocalDateTime lastLoginAt;
 
+  // 연관관계 매핑
+  @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  private CustomerProfile customerProfile;
+
   @Builder
   public User(String email, String password, String name, String phoneNumber,
       SocialProvider socialProvider, String socialId) {
@@ -77,4 +85,9 @@ public class User extends BaseEntity {
     this.isEnabled = true;
     this.onboardingCompleted = false;
   }
+
+  public void setDefaultAddress(Long addressId) {
+    this.defaultAddressId = addressId;
+  }
+
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/entity/address/CustomerAddress.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/entity/address/CustomerAddress.java
@@ -1,0 +1,66 @@
+package com.deliveranything.domain.user.entity.address;
+
+import com.deliveranything.domain.user.entity.profile.CustomerProfile;
+import com.deliveranything.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "customer_addresses")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomerAddress extends BaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "customer_profile_id", nullable = false)
+  private CustomerProfile customerProfile;
+
+  @Column(name = "address_name", length = 50)
+  private String addressName;
+
+  @Column(nullable = false, length = 100)
+  private String address;
+
+  @Column(precision = 10, scale = 7) // 10 , 7  값에 대해서는 협의 필요 (위도 경도 범위)
+  private java.math.BigDecimal latitude;
+
+  @Column(precision = 10, scale = 7)
+  private java.math.BigDecimal longitude;
+
+  @Builder
+  public CustomerAddress(CustomerProfile customerProfile, String addressName,
+      String address, java.math.BigDecimal latitude,
+      java.math.BigDecimal longitude) {
+    this.customerProfile = customerProfile;
+    this.addressName = addressName;
+    this.address = address;
+    this.latitude = latitude;
+    this.longitude = longitude;
+  }
+
+  // 비즈니스 메서드
+  public boolean isDefault() {
+    return customerProfile.getUser().getDefaultAddressId() != null &&
+        customerProfile.getUser().getDefaultAddressId().equals(this.getId());
+  }
+
+  public void setAsDefault() {
+    customerProfile.setDefaultAddress(this.getId());
+  }
+
+  public void updateAddress(String addressName, String address,
+      java.math.BigDecimal latitude, java.math.BigDecimal longitude) {
+    this.addressName = addressName;
+    this.address = address;
+    this.latitude = latitude;
+    this.longitude = longitude;
+  }
+}

--- a/backend/src/main/java/com/deliveranything/domain/user/entity/profile/CustomerProfile.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/entity/profile/CustomerProfile.java
@@ -1,0 +1,47 @@
+package com.deliveranything.domain.user.entity.profile;
+
+import com.deliveranything.domain.user.entity.User;
+import com.deliveranything.global.entity.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "customer_profiles")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CustomerProfile extends BaseEntity {
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id", nullable = false)
+  private User user;
+
+  @Column(unique = true, nullable = false, length = 20)
+  private String nickname;
+
+  @Column(name = "customer_profile_image_url", columnDefinition = "TEXT")
+  private String customerProfileImageUrl;
+
+  @Builder
+  public CustomerProfile(User user, String nickname, String customerProfileImageUrl) {
+    this.user = user;
+    this.nickname = nickname;
+    this.customerProfileImageUrl = customerProfileImageUrl;
+  }
+
+  public void setDefaultAddress(Long addressId) {
+    user.setDefaultAddress(addressId);
+  }
+
+  public void updateProfile(String nickname, String customerProfileImageUrl) {
+    this.nickname = nickname;
+    this.customerProfileImageUrl = customerProfileImageUrl;
+  }
+}

--- a/backend/src/main/java/com/deliveranything/domain/user/entity/profile/RiderProfile.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/entity/profile/RiderProfile.java
@@ -14,6 +14,7 @@ import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;

--- a/backend/src/main/java/com/deliveranything/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.deliveranything.domain.user.repository;
+
+import com.deliveranything.domain.user.entity.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  Optional<User> findByEmail(String email);
+
+  boolean existsByEmail(String email);
+
+}

--- a/backend/src/main/java/com/deliveranything/global/entity/BaseEntity.java
+++ b/backend/src/main/java/com/deliveranything/global/entity/BaseEntity.java
@@ -1,6 +1,5 @@
 package com.deliveranything.global.entity;
 
-<<<<<<< HEAD
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;

--- a/backend/src/main/java/com/deliveranything/global/entity/BaseEntity.java
+++ b/backend/src/main/java/com/deliveranything/global/entity/BaseEntity.java
@@ -1,5 +1,6 @@
 package com.deliveranything.global.entity;
 
+<<<<<<< HEAD
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;


### PR DESCRIPTION
커밋 별 설명

1. feat(be): 기초 ìUserRepository 구현 : UserRepository 기초 내용 구현하였습니다.

2. feat(be): CustomerProfile 기초구현 : CustomerProfile 엔티티를 기초 구현 하였습니다.
- 이 과정에서 User 엔티티에 setDefaultAddress 메소드를 추가했습니다! 

3. feat(be): CustomerAddress 기본구현 : CustomerAddress 엔티티를 기초 구현 하였습니다.

4. fix(be) : RiderProfile List 임포트 문제 해결 : 위 작업 이후 pull origin dev --rebase 했을 때 RiderProfile에서 import java.util.List; 을 하지 않아서 생긴 오류가 있길래 이건 제가 건드려도 될 것 같아서 추가했습니다. 

이것 외에 다른 도메인의 의존성 오류는 건드리지 않았습니당