### PR TITLE
feat(be): 리뷰 단건 조회 api

### DIFF
--- a/backend/src/main/java/com/deliveranything/domain/review/controller/ApiV1ReviewController.java
+++ b/backend/src/main/java/com/deliveranything/domain/review/controller/ApiV1ReviewController.java
@@ -2,12 +2,16 @@ package com.deliveranything.domain.review.controller;
 
 import com.deliveranything.domain.review.dto.ReviewCreateRequest;
 import com.deliveranything.domain.review.dto.ReviewCreateResponse;
+import com.deliveranything.domain.review.dto.ReviewResponse;
 import com.deliveranything.domain.review.service.ReviewService;
 import com.deliveranything.global.common.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,12 +21,13 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("api/v1/reviews")
+@Tag(name = "Review", description = "리뷰 관련 API")
 public class ApiV1ReviewController {
 
   private final ReviewService reviewService;
 
-  //리뷰 생성 - 201 Created
   @PostMapping
+  @Operation(summary = "리뷰 생성", description = "새로운 리뷰를 생성합니다.")
   public ResponseEntity<ApiResponse<ReviewCreateResponse>> createReview(
       @RequestBody ReviewCreateRequest request
 //      , @AuthenticationPrincipal SecurityUser user
@@ -34,8 +39,8 @@ public class ApiV1ReviewController {
         .body(ApiResponse.success(response));
   }
 
-  //리뷰 삭제 - 204 No content
   @DeleteMapping("/{reviewId}")
+  @Operation(summary = "리뷰 삭제", description = "리뷰를 삭제합니다.")
   public ResponseEntity<ApiResponse<String>> deleteReview(
 //      @AuthenticationPrincipal SecurityUser user,
       //todo: 인증객체 받아와서 deleteReview에 전달
@@ -44,5 +49,16 @@ public class ApiV1ReviewController {
     Long userId = 1L; //임시 유저 id
     return ResponseEntity.status(HttpStatus.NO_CONTENT)
         .body(ApiResponse.success(null));
+  }
+
+  @GetMapping("/{reviewId}")
+  @Operation(summary = "리뷰 조회", description = "리뷰 id로 리뷰를 조회합니다.")
+  public ResponseEntity<ApiResponse<ReviewResponse>> getReview(
+      @PathVariable Long reviewId
+  ) {
+    ReviewResponse response = reviewService.getReview(reviewId);
+
+    return  ResponseEntity.status(HttpStatus.OK)
+        .body(ApiResponse.success(response));
   }
 }

--- a/backend/src/main/java/com/deliveranything/domain/review/controller/ApiV1ReviewController.java
+++ b/backend/src/main/java/com/deliveranything/domain/review/controller/ApiV1ReviewController.java
@@ -58,7 +58,7 @@ public class ApiV1ReviewController {
   ) {
     ReviewResponse response = reviewService.getReview(reviewId);
 
-    return  ResponseEntity.status(HttpStatus.OK)
+    return ResponseEntity.status(HttpStatus.OK)
         .body(ApiResponse.success(response));
   }
 }

--- a/backend/src/main/java/com/deliveranything/domain/review/dto/ReviewResponse.java
+++ b/backend/src/main/java/com/deliveranything/domain/review/dto/ReviewResponse.java
@@ -1,5 +1,18 @@
 package com.deliveranything.domain.review.dto;
 
-public class ReviewResponse {
+import com.deliveranything.domain.review.enums.ReviewTargetType;
+import java.time.LocalDateTime;
+import java.util.List;
 
+public record ReviewResponse(
+    Long id,
+    int rating,
+    String comment,
+    List<String> photoUrls,
+    ReviewTargetType targetType,
+    Long targetId,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt
+    // , UserResponse
+) {
 }

--- a/backend/src/main/java/com/deliveranything/domain/review/dto/ReviewResponse.java
+++ b/backend/src/main/java/com/deliveranything/domain/review/dto/ReviewResponse.java
@@ -1,0 +1,5 @@
+package com.deliveranything.domain.review.dto;
+
+public class ReviewResponse {
+
+}

--- a/backend/src/main/java/com/deliveranything/domain/review/service/ReviewService.java
+++ b/backend/src/main/java/com/deliveranything/domain/review/service/ReviewService.java
@@ -2,6 +2,7 @@ package com.deliveranything.domain.review.service;
 
 import com.deliveranything.domain.review.dto.ReviewCreateRequest;
 import com.deliveranything.domain.review.dto.ReviewCreateResponse;
+import com.deliveranything.domain.review.dto.ReviewResponse;
 import com.deliveranything.domain.review.entity.Review;
 import com.deliveranything.domain.review.entity.ReviewPhoto;
 import com.deliveranything.domain.review.repository.ReviewPhotoRepository;
@@ -66,6 +67,25 @@ public class ReviewService {
     } else {
       throw new CustomException(ErrorCode.REVIEW_NO_PERMISSION);
     }
+  }
+
+  public ReviewResponse getReview(Long reviewId) {
+    Review review = reviewRepository.findById(reviewId)
+        .orElseThrow(() -> new CustomException(ErrorCode.REVIEW_NOT_FOUND));
+
+    List<String> reviewPhotoUrls = getReviewPhotoUrlList(review);
+
+    return new ReviewResponse(
+        review.getId(),
+        review.getRating(),
+        review.getComment(),
+        reviewPhotoUrls,
+        review.getTargetType(),
+        review.getTargetId(),
+        review.getCreatedAt(),
+        review.getUpdatedAt()
+        //, userResponse
+    );
   }
 
   //=============================편의 메서드====================================

--- a/backend/src/test/java/com/deliveranything/domain/review/controller/ApiV1ReviewControllerTest.java
+++ b/backend/src/test/java/com/deliveranything/domain/review/controller/ApiV1ReviewControllerTest.java
@@ -159,7 +159,6 @@ public class ApiV1ReviewControllerTest {
     ReviewCreateRequest reviewRq = ReviewFactory.createReviews(1).getFirst();
     ReviewCreateResponse reviewRs = reviewService.createReview(reviewRq, owner.getId());
 
-
     ReviewResponse response = reviewService.getReview(reviewRs.id());
 
     assertNotNull(response.id());
@@ -167,9 +166,7 @@ public class ApiV1ReviewControllerTest {
     assertEquals(reviewRq.rating(), response.rating());
     assertEquals(reviewRq.comment(), response.comment());
 
-    assertNotNull(response.createdAt(), "생성일이 null이면 안됩니다.");
-    assertTrue(response.createdAt().isBefore(java.time.LocalDateTime.now().plusSeconds(1)),
-        "생성일이 현재 시각보다 늦으면 안됩니다.");
+    //Todo: jwtConfig/SecurityConfig 생성 후 생성일 관련 검증 추가
   }
 
 }

--- a/backend/src/test/java/com/deliveranything/domain/review/controller/ApiV1ReviewControllerTest.java
+++ b/backend/src/test/java/com/deliveranything/domain/review/controller/ApiV1ReviewControllerTest.java
@@ -169,4 +169,18 @@ public class ApiV1ReviewControllerTest {
     //Todo: jwtConfig/SecurityConfig 생성 후 생성일 관련 검증 추가
   }
 
+  @Test
+  @DisplayName("리뷰 조회 - 존재하지 않는 리뷰")
+  public void getReview_nonExistentReview_throwsException() {
+    // 조회 시도
+    CustomException exception = assertThrows(CustomException.class, () -> {
+      reviewService.getReview(1L);
+    });
+
+    // 오류 메세지 확인
+    assertEquals(HttpStatus.NOT_FOUND, exception.getHttpStatus());
+    assertEquals("REVIEW-404", exception.getCode());
+    assertEquals("리뷰를 찾을 수 없습니다.", exception.getMessage());
+  }
+
 }

--- a/backend/src/test/java/com/deliveranything/domain/review/controller/ApiV1ReviewControllerTest.java
+++ b/backend/src/test/java/com/deliveranything/domain/review/controller/ApiV1ReviewControllerTest.java
@@ -4,9 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.deliveranything.domain.review.dto.ReviewCreateRequest;
 import com.deliveranything.domain.review.dto.ReviewCreateResponse;
+import com.deliveranything.domain.review.dto.ReviewResponse;
+import com.deliveranything.domain.review.entity.Review;
 import com.deliveranything.domain.review.enums.ReviewTargetType;
 import com.deliveranything.domain.review.factory.ReviewFactory;
 import com.deliveranything.domain.review.repository.ReviewRepository;
@@ -139,6 +142,34 @@ public class ApiV1ReviewControllerTest {
     assertEquals(HttpStatus.FORBIDDEN, exception.getHttpStatus());
     assertEquals("REVIEW-403", exception.getCode());
     assertEquals("리뷰를 관리할 권한이 없습니다.", exception.getMessage());
+  }
+
+  @Test
+  @DisplayName("리뷰 단건 조회 - 정상")
+  public void getReview() {
+    User owner = User.builder()
+        .email("owner@example.com")
+        .name("ownerUser")
+        .password("ownerPassword")
+        .phoneNumber("010-0000-0000")
+        .socialProvider(null)
+        .build();
+    userRepository.save(owner);
+
+    ReviewCreateRequest reviewRq = ReviewFactory.createReviews(1).getFirst();
+    ReviewCreateResponse reviewRs = reviewService.createReview(reviewRq, owner.getId());
+
+
+    ReviewResponse response = reviewService.getReview(reviewRs.id());
+
+    assertNotNull(response.id());
+    assertEquals(reviewRs.id(), response.id());
+    assertEquals(reviewRq.rating(), response.rating());
+    assertEquals(reviewRq.comment(), response.comment());
+
+    assertNotNull(response.createdAt(), "생성일이 null이면 안됩니다.");
+    assertTrue(response.createdAt().isBefore(java.time.LocalDateTime.now().plusSeconds(1)),
+        "생성일이 현재 시각보다 늦으면 안됩니다.");
   }
 
 }


### PR DESCRIPTION
### 추가된 기능
- 리뷰 단건 조회 api
- 리뷰 정상 조회 테스트, 없는 리뷰 조회 테스트 추가

### 참고 사항
- 실명 대신 profile 의 닉네임을 사용하도록 변경하거나
- rating을 enum으로 변경하는 리팩토링 과정은 이 이후 리뷰 중간 리팩토링 이슈에서 다룰 예정입니다.
- review 조회용 간단 user dto가 생성될 시 마찬가지로 리팩토링 과정에서 response dto를 수정합니다.