### PR TITLE
feat(be): 유저 서비스 구현 + 유저 엔티티 리팩토링,dto 구현

### DIFF
--- a/backend/src/main/java/com/deliveranything/domain/user/entity/User.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/entity/User.java
@@ -115,4 +115,12 @@ public class User extends BaseEntity {
   public void switchProfile(ProfileType targetProfile) {
     this.currentActiveProfile = targetProfile;
   }
+
+  public void enable() {
+    this.isEnabled = true;
+  }
+
+  public void disable() {
+    this.isEnabled = false;
+  }
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/entity/User.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/entity/User.java
@@ -115,5 +115,4 @@ public class User extends BaseEntity {
   public void switchProfile(ProfileType targetProfile) {
     this.currentActiveProfile = targetProfile;
   }
-
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/entity/User.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/entity/User.java
@@ -90,4 +90,30 @@ public class User extends BaseEntity {
     this.defaultAddressId = addressId;
   }
 
+  public void updateBasicInfo(String name, String phoneNumber) {
+    this.name = name;
+    this.phoneNumber = phoneNumber;
+  }
+
+  public void updatePassword(String newPassword) {
+    this.password = newPassword;
+  }
+
+  public void verifyEmail() {
+    this.isEmailVerified = true;
+  }
+
+  public void updateLastLoginAt() {
+    this.lastLoginAt = LocalDateTime.now();
+  }
+
+  public void completeOnboarding(ProfileType selectedProfile) {
+    this.currentActiveProfile = selectedProfile;
+    this.onboardingCompleted = true;
+  }
+
+  public void switchProfile(ProfileType targetProfile) {
+    this.currentActiveProfile = targetProfile;
+  }
+
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/enums/ProfileType.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/enums/ProfileType.java
@@ -4,7 +4,7 @@ package com.deliveranything.domain.user.enums;
  * 프로필 타입 enum
  */
 public enum ProfileType {
-  CONSUMER("소비자"),
+  CUSTOMER("소비자"),
   SELLER("판매자"),
   RIDER("배달원");
 

--- a/backend/src/main/java/com/deliveranything/domain/user/repository/UserRepository.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/repository/UserRepository.java
@@ -10,4 +10,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
   boolean existsByEmail(String email);
 
+  boolean existsByPhoneNumber(String phoneNumber);
+  
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/service/UserService.java
@@ -1,0 +1,63 @@
+package com.deliveranything.domain.user.service;
+
+import com.deliveranything.domain.user.entity.User;
+import com.deliveranything.domain.user.repository.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+  private final UserRepository userRepository;
+
+  // 기본 조회 Methods
+  public User findById(Long id) {
+    return userRepository.findById(id).orElse(null);
+  }
+
+  public Optional<User> findByIdOptional(Long id) {
+    return userRepository.findById(id);
+  }
+
+  public User findByEmail(String email) {
+    return userRepository.findByEmail(email).orElse(null);
+  }
+
+  // 중복 체크 Methods
+  public boolean existsByEmail(String email) {
+    return userRepository.existsByEmail(email);
+  }
+
+  public boolean existsByPhoneNumber(String phoneNumber) {
+    return userRepository.existsByPhoneNumber(phoneNumber);
+  }
+
+  // 기본 정보 수정 Methods
+  @Transactional
+  public void updateBasicInfo(Long userId, String name, String phoneNumber) {
+    User user = findById(userId);
+    if (user == null) {
+      log.warn("사용자를 찾을 수 없습니다: userId={}", userId);
+      return;
+    }
+    // 핸드폰 번호 중복 체크 (본인 제외)
+    if (!user.getPhoneNumber().equals(phoneNumber) &&
+        existsByPhoneNumber(phoneNumber)) {
+      log.warn("이미 사용 중인 전화번호입니다: phoneNumber={}", phoneNumber);
+      return;
+    }
+
+    user.updateBasicInfo(name, phoneNumber);
+    userRepository.save(user);
+
+    log.info("사용자 기본 정보 업데이트 완료: userId={}", userId);
+  }
+
+
+}

--- a/backend/src/main/java/com/deliveranything/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/service/UserService.java
@@ -111,16 +111,48 @@ public class UserService {
   public boolean canSwitchToProfile(Long userId, ProfileType targetProfile) {
     User user = findById(userId);
     if (user == null) {
+      return false;
+    }
+    return canSwitchToProfileInternal(user, targetProfile);
+  }
+
+  // 온보딩 관련 Methods
+  @Transactional
+  public boolean completeOnboarding(Long userId, ProfileType selectedProfile) {
+    User user = findById(userId);
+    if (user == null) {
       log.warn("사용자를 찾을 수 없습니다: userId={}", userId);
       return false;
     }
-    if (!user.isOnboardingCompleted()) {
-      log.warn("온보딩이 완료되지 않은 사용자입니다: userId={}", userId);
+
+    // 이미 온보딩 완료된 경우
+    if (user.isOnboardingCompleted()) {
+      log.warn("이미 온보딩이 완료되었습니다: userId={}", userId);
       return false;
     }
-    List<ProfileType> availableProfiles = getAvailableProfilesInternal(user);
-    return availableProfiles.contains(targetProfile);
+
+    // 선택한 프로필이 존재하는지 확인 (Service에서 직접 처리)
+    if (!hasProfileInternal(user, selectedProfile)) {
+      log.warn("해당 프로필을 찾을 수 없습니다: userId={}, selectedProfile={}", userId, selectedProfile);
+      return false;
+    }
+
+    // 단순 상태 변경
+    user.completeOnboarding(selectedProfile);
+    userRepository.save(user);
+
+    log.info("온보딩 완료: userId={}, selectedProfile={}", userId, selectedProfile);
+    return true;
   }
+
+  public boolean isOnboardingCompleted(Long userId) {
+    User user = findById(userId);
+    if (user == null) {
+      return false;
+    }
+    return user.isOnboardingCompleted();
+  }
+
 
   // 프로필 관리를 위한 Private Helper Methods
   private List<ProfileType> getAvailableProfilesInternal(User user) {
@@ -132,6 +164,26 @@ public class UserService {
     // TODO: SellerProfile, RiderProfile 연관관계 추가 시 로직 확장
 
     return profiles;
+  }
+
+  private boolean canSwitchToProfileInternal(User user, ProfileType targetProfile) {
+    if (!user.isOnboardingCompleted()) {
+      return false;
+    }
+
+    return switch (targetProfile) {
+      case CONSUMER -> user.getCustomerProfile() != null;
+      case SELLER -> false; // TODO: 나중에 SellerProfile 연관관계 추가 시 수정
+      case RIDER -> false;  // TODO: 나중에 RiderProfile 연관관계 추가 시 수정
+    };
+  }
+
+  private boolean hasProfileInternal(User user, ProfileType profileType) {
+    return switch (profileType) {
+      case CONSUMER -> user.getCustomerProfile() != null;
+      case SELLER -> false; // TODO: 나중에 수정
+      case RIDER -> false;  // TODO: 나중에 수정
+    };
   }
 
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/service/UserService.java
@@ -153,6 +153,55 @@ public class UserService {
     return user.isOnboardingCompleted();
   }
 
+  // 기타 Methods
+  @Transactional
+  public void updateLastLoginAt(Long userId) {
+    User user = findById(userId);
+    if (user == null) {
+      log.warn("사용자를 찾을 수 없습니다: userId={}", userId);
+      return;
+    }
+
+    user.updateLastLoginAt();
+    userRepository.save(user);
+
+    log.info("사용자 마지막 로그인 시간 업데이트 완료: userId={}", userId);
+  }
+
+  // 기본주소 설정
+  public boolean setDefaultAddress(Long userId, Long addressId) {
+    User user = findById(userId);
+    if (user == null) {
+      log.warn("사용자를 찾을 수 없습니다: userId={}", userId);
+      return false;
+    }
+    // 소비자 프로필 존재 확인
+    if (!hasProfileInternal(user, ProfileType.CONSUMER)) {
+      log.warn("소비자 프로필을 찾을 수 없습니다: userId={}", userId);
+      return false;
+    }
+
+    user.setDefaultAddress(addressId);
+    userRepository.save(user);
+
+    log.info("기본 주소 설정 완료: userId={}, addressId={}", userId, addressId);
+    return true;
+  }
+
+  // 이메일 인증 처리 임시
+  @Transactional
+  public void verifyEmail(Long userId) {
+    User user = findById(userId);
+    if (user == null) {
+      log.warn("사용자를 찾을 수 없습니다: userId={}", userId);
+      return;
+    }
+
+    user.verifyEmail();
+    userRepository.save(user);
+
+    log.info("이메일 인증 완료: userId={}", userId);
+  }
 
   // 프로필 관리를 위한 Private Helper Methods
   private List<ProfileType> getAvailableProfilesInternal(User user) {
@@ -165,6 +214,7 @@ public class UserService {
 
     return profiles;
   }
+
 
   private boolean canSwitchToProfileInternal(User user, ProfileType targetProfile) {
     if (!user.isOnboardingCompleted()) {

--- a/backend/src/main/java/com/deliveranything/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/service/UserService.java
@@ -156,7 +156,7 @@ public class UserService {
       return false;
     }
     // 소비자 프로필 존재 확인
-    if (!hasProfileInternal(user, ProfileType.CONSUMER)) {
+    if (!hasProfileInternal(user, ProfileType.CUSTOMER)) {
       log.warn("소비자 프로필을 찾을 수 없습니다: userId={}", userId);
       return false;
     }
@@ -291,7 +291,7 @@ public class UserService {
     List<ProfileType> profiles = new ArrayList<>();
 
     if (user.getCustomerProfile() != null) {
-      profiles.add(ProfileType.CONSUMER);
+      profiles.add(ProfileType.CUSTOMER);
     }
     // TODO: SellerProfile, RiderProfile 연관관계 추가 시 로직 확장
 
@@ -305,7 +305,7 @@ public class UserService {
     }
 
     return switch (targetProfile) {
-      case CONSUMER -> user.getCustomerProfile() != null;
+      case CUSTOMER -> user.getCustomerProfile() != null;
       case SELLER -> false; // TODO: 나중에 SellerProfile 연관관계 추가 시 수정
       case RIDER -> false;  // TODO: 나중에 RiderProfile 연관관계 추가 시 수정
     };
@@ -313,7 +313,7 @@ public class UserService {
 
   private boolean hasProfileInternal(User user, ProfileType profileType) {
     return switch (profileType) {
-      case CONSUMER -> user.getCustomerProfile() != null;
+      case CUSTOMER -> user.getCustomerProfile() != null;
       case SELLER -> false; // TODO: 나중에 수정
       case RIDER -> false;  // TODO: 나중에 수정
     };


### PR DESCRIPTION
커밋 1 (e60f7350e2949448980e2a54e9bb79b02f92dc75 ): User service를 만들면서 생긴 추가 요구사항을 반영해 User 엔티티 리팩토링 했습니다

커밋 2 (2bfa3fb09a823c00d0b30c0aafb8abac3743e6f6): 프로필 관리 로직을 만들면서 관련 헬퍼 메소드를 도입해봤습니다.

커밋 3 (db9cea1420acb932e35868f5592f2caa86619dab) : 회원가입 후 필요한 온보딩 로직을 구현했습니다.

커밋 4 : (fb70f1e8d37c814bd3657572a451d5f9aa7f8c63) : 유저 서비스 기초적인 로직을 구현완료 했습니다. (기본 주소 설정, 임시 이메일 인증 처리 로직 등 )

커밋 5 : (5b8eab3daf59beeb03bcb2c26ceb6af15a18754e) : 회원가입 탈퇴와 임시 로그인 로직, 계정 비활성화 등 구현했습니다

커밋 6 : (50226f30b863724a0ce31a92a71c15720636fd6c) : 기존 합의된 설계에 맞게 ProfileType enum파일에 소비자가 CONSUMER로 명명 되어 있던걸 CUSTOMER로 변경했습니다.

커밋 7 : (b860c4e7000701588bb8dff6cbf864cd2d443b67) : CUSTMOER로 이름을 바꾸면서 해당 enum을 사용하던 UserService 내 코드를 리팩토링 하였습니다. 



아직 서비스 코드랑 엔티티를 만질게 많을 것 같아 중간 저장 느낌으로 dev에 PR 남겼습니다! 