### PR TITLE
feat(be): CustomerProfileService 기초 API 구현

### DIFF
--- a/backend/src/main/java/com/deliveranything/domain/user/entity/User.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/entity/User.java
@@ -63,10 +63,6 @@ public class User extends BaseEntity {
   @Column(name = "onboarding_completed", nullable = false)
   private boolean onboardingCompleted;
 
-  // 기타
-  @Column(name = "default_address_id")
-  private Long defaultAddressId;
-
   @Column(name = "last_login_at")
   private LocalDateTime lastLoginAt;
 
@@ -90,10 +86,6 @@ public class User extends BaseEntity {
     this.isEmailVerified = false;
     this.isEnabled = true;
     this.onboardingCompleted = false;
-  }
-
-  public void setDefaultAddress(Long addressId) {
-    this.defaultAddressId = addressId;
   }
 
   public void updateBasicInfo(String name, String phoneNumber) {

--- a/backend/src/main/java/com/deliveranything/domain/user/entity/User.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/entity/User.java
@@ -88,11 +88,6 @@ public class User extends BaseEntity {
     this.onboardingCompleted = false;
   }
 
-  public void updateBasicInfo(String name, String phoneNumber) {
-    this.name = name;
-    this.phoneNumber = phoneNumber;
-  }
-
   public void updatePassword(String newPassword) {
     this.password = newPassword;
   }

--- a/backend/src/main/java/com/deliveranything/domain/user/entity/address/CustomerAddress.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/entity/address/CustomerAddress.java
@@ -48,12 +48,8 @@ public class CustomerAddress extends BaseEntity {
 
   // 비즈니스 메서드
   public boolean isDefault() {
-    return customerProfile.getUser().getDefaultAddressId() != null &&
-        customerProfile.getUser().getDefaultAddressId().equals(this.getId());
-  }
-
-  public void setAsDefault() {
-    customerProfile.setDefaultAddress(this.getId());
+    return customerProfile.getDefaultAddressId() != null &&
+        customerProfile.getDefaultAddressId().equals(this.getId());
   }
 
   public void updateAddress(String addressName, String address,

--- a/backend/src/main/java/com/deliveranything/domain/user/entity/address/CustomerAddress.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/entity/address/CustomerAddress.java
@@ -30,15 +30,15 @@ public class CustomerAddress extends BaseEntity {
   private String address;
 
   @Column(precision = 10, scale = 7) // 10 , 7  값에 대해서는 협의 필요 (위도 경도 범위)
-  private java.math.BigDecimal latitude;
+  private Double latitude;
 
   @Column(precision = 10, scale = 7)
-  private java.math.BigDecimal longitude;
+  private Double longitude;
 
   @Builder
   public CustomerAddress(CustomerProfile customerProfile, String addressName,
-      String address, java.math.BigDecimal latitude,
-      java.math.BigDecimal longitude) {
+      String address, Double latitude,
+      Double longitude) {
     this.customerProfile = customerProfile;
     this.addressName = addressName;
     this.address = address;
@@ -57,7 +57,7 @@ public class CustomerAddress extends BaseEntity {
   }
 
   public void updateAddress(String addressName, String address,
-      java.math.BigDecimal latitude, java.math.BigDecimal longitude) {
+      Double latitude, Double longitude) {
     this.addressName = addressName;
     this.address = address;
     this.latitude = latitude;

--- a/backend/src/main/java/com/deliveranything/domain/user/entity/profile/CustomerProfile.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/entity/profile/CustomerProfile.java
@@ -24,6 +24,9 @@ public class CustomerProfile extends BaseProfile {
   @JoinColumn(name = "user_id", nullable = false)
   private User user;
 
+  // 기타
+  @Column(name = "default_address_id")
+  private Long defaultAddressId;
 
   @Builder
   public CustomerProfile(User user, String nickname, String profileImageUrl) {
@@ -32,7 +35,7 @@ public class CustomerProfile extends BaseProfile {
   }
 
   public void setDefaultAddress(Long addressId) {
-    user.setDefaultAddress(addressId);
+    this.setDefaultAddress(addressId);
   }
 
   public void updateProfile(String nickname, String profileImageUrl) {

--- a/backend/src/main/java/com/deliveranything/domain/user/entity/profile/CustomerProfile.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/entity/profile/CustomerProfile.java
@@ -34,12 +34,13 @@ public class CustomerProfile extends BaseProfile {
     this.user = user;
   }
 
-  public void setDefaultAddress(Long addressId) {
-    this.setDefaultAddress(addressId);
-  }
-
   public void updateProfile(String nickname, String profileImageUrl) {
     super.updateNickname(nickname);
     super.updateProfileImageUrl(profileImageUrl);
   }
+
+  public void updateDefaultAddressId(Long addressId) {
+    this.defaultAddressId = addressId;
+  }
+
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/repository/CustomerAddressRepository.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/repository/CustomerAddressRepository.java
@@ -1,0 +1,8 @@
+package com.deliveranything.domain.user.repository;
+
+import com.deliveranything.domain.user.entity.address.CustomerAddress;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomerAddressRepository extends JpaRepository<CustomerAddress, Long> {
+  
+}

--- a/backend/src/main/java/com/deliveranything/domain/user/repository/CustomerAddressRepository.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/repository/CustomerAddressRepository.java
@@ -1,8 +1,14 @@
 package com.deliveranything.domain.user.repository;
 
 import com.deliveranything.domain.user.entity.address.CustomerAddress;
+import com.deliveranything.domain.user.entity.profile.CustomerProfile;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface CustomerAddressRepository extends JpaRepository<CustomerAddress, Long> {
-  
+
+  @Query("SELECT ca FROM CustomerAddress ca WHERE ca.customerProfile = :profile ORDER BY ca.id ASC")
+  List<CustomerAddress> findAddressesByProfile(@Param("profile") CustomerProfile profile);
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/repository/CustomerAddressRepository.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/repository/CustomerAddressRepository.java
@@ -11,4 +11,6 @@ public interface CustomerAddressRepository extends JpaRepository<CustomerAddress
 
   @Query("SELECT ca FROM CustomerAddress ca WHERE ca.customerProfile = :profile ORDER BY ca.id ASC")
   List<CustomerAddress> findAddressesByProfile(@Param("profile") CustomerProfile profile);
+
+  long countByCustomerProfile(CustomerProfile profile);
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/service/CustomerProfileService.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/service/CustomerProfileService.java
@@ -1,10 +1,12 @@
 package com.deliveranything.domain.user.service;
 
 import com.deliveranything.domain.user.entity.User;
+import com.deliveranything.domain.user.entity.address.CustomerAddress;
 import com.deliveranything.domain.user.entity.profile.CustomerProfile;
 import com.deliveranything.domain.user.repository.CustomerAddressRepository;
 import com.deliveranything.domain.user.repository.CustomerProfileRepository;
 import com.deliveranything.domain.user.repository.UserRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -89,5 +91,18 @@ public class CustomerProfileService {
     log.info("고객 프로필 수정 완료: userId={}, nickname={}", userId, nickname);
     return true;
   }
-  
+
+  // 배송지 관리
+
+  // 모든 배송지 조회
+  public List<CustomerAddress> getAddresses(Long userId) {
+    CustomerProfile profile = getProfile(userId);
+    if (profile == null) {
+      log.warn("고객 프로필을 찾을 수 없습니다.: userId={}", userId);
+      return List.of();
+    }
+
+    return customerAddressRepository.findAddressesByProfile(profile);
+  }
+
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/service/CustomerProfileService.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/service/CustomerProfileService.java
@@ -229,4 +229,31 @@ public class CustomerProfileService {
     return customerAddressRepository.findById(profile.getDefaultAddressId()).orElse(null);
   }
 
+  // 사용자의 기본 배송지 ID 조회
+  public Long getDefaultAddressId(Long userId) {
+    CustomerProfile profile = getProfile(userId);
+    if (profile == null) {
+      return null;
+    }
+    return profile.getDefaultAddressId();
+  }
+
+  // 배송지 개수 조회
+  public long countAddresses(Long userId) {
+    CustomerProfile profile = getProfile(userId);
+    if (profile == null) {
+      return 0;
+    }
+    return customerAddressRepository.countByCustomerProfile(profile);
+  }
+
+  // 배송지가 기본 배송지인지 확인
+  public boolean isDefaultAddress(Long userId, Long addressId) {
+    CustomerProfile profile = getProfile(userId);
+    if (profile == null || profile.getDefaultAddressId() == null) {
+      return false;
+    }
+    return profile.getDefaultAddressId().equals(addressId);
+  }
+
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/service/CustomerProfileService.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/service/CustomerProfileService.java
@@ -1,0 +1,78 @@
+package com.deliveranything.domain.user.service;
+
+import com.deliveranything.domain.user.entity.User;
+import com.deliveranything.domain.user.entity.profile.CustomerProfile;
+import com.deliveranything.domain.user.repository.CustomerAddressRepository;
+import com.deliveranything.domain.user.repository.CustomerProfileRepository;
+import com.deliveranything.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CustomerProfileService {
+
+  private final UserRepository userRepository;
+  private final CustomerProfileRepository customerProfileRepository;
+  private final CustomerAddressRepository customerAddressRepository;
+
+// 고객 프로필 관리
+
+  // 고객 프로필 생성 (UserService에서 온보딩 시 호출 예정)
+  @Transactional
+  public CustomerProfile createProfile(Long userId, String nickname) {
+    User user = userRepository.findById(userId).orElse(null);
+    if (user == null) {
+      log.warn("사용자를 찾을 수 없습니다: userId={}", userId);
+      return null;
+    }
+
+    // 이미 고객 프로필이 존재하는 경우
+    if (user.getCustomerProfile() != null) {
+      log.warn("이미 고객 프로필이 존재합니다: userId={}", userId);
+      return user.getCustomerProfile();
+    }
+
+    CustomerProfile customerProfile = CustomerProfile.builder()
+        .user(user)
+        .nickname(nickname)
+        .profileImageUrl(null)  // 기본값
+        .build();
+
+    customerProfileRepository.save(customerProfile);
+    log.info("고객 프로필 생성 완료: userId={}, profileId={}", userId, customerProfile.getId());
+
+    return customerProfile;
+  }
+
+  //고객 프로필 조회
+  public CustomerProfile getProfile(Long userId) {
+    User user = userRepository.findById(userId).orElse(null);
+    if (user == null) {
+      log.warn("사용자를 찾을 수 없습니다: userId={}", userId);
+      return null;
+    }
+
+    CustomerProfile profile = user.getCustomerProfile();
+    if (profile == null) {
+      log.warn("고객 프로필을 찾을 수 없습니다: userId={}", userId);
+      return null;
+    }
+
+    return profile;
+  }
+
+  // 고객 프로필 존재 여부 확인
+  public boolean hasProfile(Long userId) {
+    User user = userRepository.findById(userId).orElse(null);
+    if (user == null) {
+      return false;
+    }
+    return user.getCustomerProfile() != null;
+  }
+  
+}

--- a/backend/src/main/java/com/deliveranything/domain/user/service/CustomerProfileService.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/service/CustomerProfileService.java
@@ -149,6 +149,12 @@ public class CustomerProfileService {
     customerAddressRepository.save(customerAddress);
     log.info("배송지 추가 완료: userId={}, addressId={}", userId, customerAddress.getId());
 
+    // 첫 번째 주소는 자동으로 기본 설정
+    if (profile.getDefaultAddressId() == null) {
+      profile.setDefaultAddress(customerAddress.getId());
+      customerProfileRepository.save(profile);
+    }
+
     return customerAddress;
   }
 
@@ -204,7 +210,7 @@ public class CustomerProfileService {
       return false;
     }
 
-    // User 엔티티의 기본 주소 ID 업데이트 ( CustomerAddress -> CustomerProfiel -> User의 default_address_id 참조...인데 기본 배송지 주소를 User가 가지기보단 CustomerProfile이 가지는게 더 맞지 않는 것 같아 수정 예정)
+    // CustomerProfile 엔티티의 기본 주소 ID 업데이트
     customerAddress.setAsDefault();
 
     log.info("기본 배송지 설정 완료: userId={}, addressId={}", userId, addressId);

--- a/backend/src/main/java/com/deliveranything/domain/user/service/CustomerProfileService.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/service/CustomerProfileService.java
@@ -105,4 +105,110 @@ public class CustomerProfileService {
     return customerAddressRepository.findAddressesByProfile(profile);
   }
 
+  // 특정 배송지 조회
+  public CustomerAddress getAddress(Long userId, Long addressId) {
+    CustomerProfile profile = getProfile(userId);
+    if (profile == null) {
+      log.warn("고객 프로필을 찾을 수 없습니다.: userId={}", userId);
+      return null;
+    }
+
+    CustomerAddress address = customerAddressRepository.findById(addressId).orElse(null);
+    if (address == null) {
+      log.warn("배송지를 찾을 수 없습니다: addressId={}", addressId);
+      return null;
+    }
+
+    // 권한 체크 : 해당 사용자의 배송지인지 확인
+    if (!address.getCustomerProfile().getId().equals(profile.getId())) {
+      log.warn("배송지 접근 권한이 없습니다: userId={}, addressId={}", userId, addressId);
+      return null;
+    }
+
+    return address;
+  }
+
+  // 배송지 추가
+  @Transactional
+  public CustomerAddress addAddress(Long userId, String addressName, String address,
+      Double latitude, Double longitude) {
+    CustomerProfile profile = getProfile(userId);
+    if (profile == null) {
+      log.warn("고객 프로필을 찾을 수 없습니다.: userId={}", userId);
+      return null;
+    }
+
+    CustomerAddress customerAddress = CustomerAddress.builder()
+        .customerProfile(profile)
+        .addressName(addressName)
+        .address(address)
+        .latitude(latitude)
+        .longitude(longitude)
+        .build();
+
+    customerAddressRepository.save(customerAddress);
+    log.info("배송지 추가 완료: userId={}, addressId={}", userId, customerAddress.getId());
+
+    return customerAddress;
+  }
+
+  // 배송지 수정
+  @Transactional
+  public boolean updateAddress(Long userId, Long addressId, String addressName, String address,
+      Double latitude, Double longitude) {
+    CustomerAddress customerAddress = getAddress(userId, addressId);
+    if (customerAddress == null) {
+      return false;
+    }
+
+    customerAddress.updateAddress(addressName, address, latitude, longitude);
+
+    customerAddressRepository.save(customerAddress);
+
+    log.info("배송지 수정 완료: userId={}, addressId={}", userId, addressId);
+    return true;
+  }
+
+  // 배송지 삭제
+  @Transactional
+  public boolean deleteAddress(Long userId, Long addressId) {
+    CustomerAddress customerAddress = getAddress(userId, addressId);
+    if (customerAddress == null) {
+      return false;
+    }
+
+    /**
+     * 기본 배송지인 경우 삭제 불가 처리
+     * 사용자 플로우:
+     * 1. 기본 배송지 삭제 시도
+     * 2. 서비스에서 기본 배송지 삭제 불가 응답 ("다른 주소를 먼저 기본으로 설정해주세요")
+     * 3. 사용자가 다른 주소를 기본 배송지로 설정
+     * 4. 이후 다시 기본 배송지였던 기존 주소 삭제 시도 가능
+     * -> 비즈니스 연속성과 사용자 경험 최적화(실수 방지 등)
+     */
+    if (customerAddress.isDefault()) {
+      log.warn("기본 배송지는 삭제할 수 없습니다: userId={}, addressId={}", userId, addressId);
+      return false;
+    }
+
+    customerAddressRepository.delete(customerAddress);
+    log.info("배송지 삭제 완료: userId={}, addressId={}", userId, addressId);
+    return true;
+  }
+
+  // 기본 배송지 설정
+  @Transactional
+  public boolean setDefaultAddress(Long userId, Long addressId) {
+    CustomerAddress customerAddress = getAddress(userId, addressId);
+    if (customerAddress == null) {
+      return false;
+    }
+
+    // User 엔티티의 기본 주소 ID 업데이트 ( CustomerAddress -> CustomerProfiel -> User의 default_address_id 참조...인데 기본 배송지 주소를 User가 가지기보단 CustomerProfile이 가지는게 더 맞지 않는 것 같아 수정 예정)
+    customerAddress.setAsDefault();
+
+    log.info("기본 배송지 설정 완료: userId={}, addressId={}", userId, addressId);
+    return true;
+  }
+
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/service/CustomerProfileService.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/service/CustomerProfileService.java
@@ -151,7 +151,7 @@ public class CustomerProfileService {
 
     // 첫 번째 주소는 자동으로 기본 설정
     if (profile.getDefaultAddressId() == null) {
-      profile.setDefaultAddress(customerAddress.getId());
+      profile.updateDefaultAddressId(customerAddress.getId());
       customerProfileRepository.save(profile);
     }
 
@@ -205,16 +205,28 @@ public class CustomerProfileService {
   // 기본 배송지 설정
   @Transactional
   public boolean setDefaultAddress(Long userId, Long addressId) {
+    CustomerProfile profile = getProfile(userId);
+    // 해당 주소가 이 사용자 소유인지 확인
     CustomerAddress customerAddress = getAddress(userId, addressId);
     if (customerAddress == null) {
       return false;
     }
 
     // CustomerProfile 엔티티의 기본 주소 ID 업데이트
-    customerAddress.setAsDefault();
+    profile.updateDefaultAddressId(addressId);
 
     log.info("기본 배송지 설정 완료: userId={}, addressId={}", userId, addressId);
     return true;
+  }
+
+  // 현재 기본 배송지 조회
+  public CustomerAddress getCurrentAddress(Long userId) {
+    CustomerProfile profile = getProfile(userId);
+    if (profile == null || profile.getDefaultAddressId() == null) {
+      return null;
+    }
+
+    return customerAddressRepository.findById(profile.getDefaultAddressId()).orElse(null);
   }
 
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/service/CustomerProfileService.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/service/CustomerProfileService.java
@@ -74,5 +74,20 @@ public class CustomerProfileService {
     }
     return user.getCustomerProfile() != null;
   }
+
+  // 고객 프로필 수정
+  @Transactional
+  public boolean updateProfile(Long userId, String nickname, String profileImageUrl) {
+    CustomerProfile profile = getProfile(userId);
+    if (profile == null) {
+      return false;
+    }
+
+    profile.updateProfile(nickname, profileImageUrl);
+    customerProfileRepository.save(profile);
+
+    log.info("고객 프로필 수정 완료: userId={}, nickname={}", userId, nickname);
+    return true;
+  }
   
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/service/UserService.java
@@ -147,27 +147,7 @@ public class UserService {
 
     log.info("사용자 마지막 로그인 시간 업데이트 완료: userId={}", userId);
   }
-
-  // 기본주소 설정
-  public boolean setDefaultAddress(Long userId, Long addressId) {
-    User user = findById(userId);
-    if (user == null) {
-      log.warn("사용자를 찾을 수 없습니다: userId={}", userId);
-      return false;
-    }
-    // 소비자 프로필 존재 확인
-    if (!hasProfileInternal(user, ProfileType.CUSTOMER)) {
-      log.warn("소비자 프로필을 찾을 수 없습니다: userId={}", userId);
-      return false;
-    }
-
-    user.setDefaultAddress(addressId);
-    userRepository.save(user);
-
-    log.info("기본 주소 설정 완료: userId={}, addressId={}", userId, addressId);
-    return true;
-  }
-
+  
   // 이메일 인증 처리 임시
   @Transactional
   public void verifyEmail(Long userId) {


### PR DESCRIPTION
커밋 1 9c6be6b4065ed563355a378cd5996adbbe391157 : Customer 프로필을 생성하고 조회하는 기능을 구현했습니다.

커밋 2 655e5b6d140de39d8ae45c1897a60d725738e292 : Customer 프로필을 수정하는 기능을 구현했습니다.

커밋 3 48551b86b41fc88a0497f70b388c97174cde73b7 : Customer가 추가한 모든 배송지를 조회하는 기능을 구현했습니다.

커밋 4 808e382ad37c1cd1bb8ec684e8b25730e8e9783d : 특정 배송지 조회, 배송지 CRUD, 기본 배송지 설정하는 기능을 구현했습니다. 
** 기본 배송지의 경우 삭제가 불가능하게끔 처리했습니다! 
    /**
     * 기본 배송지인 경우 삭제 불가 처리
     * 사용자 플로우:
     * 1. 기본 배송지 삭제 시도
     * 2. 서비스에서 기본 배송지 삭제 불가 응답 ("다른 주소를 먼저 기본으로 설정해주세요")
     * 3. 사용자가 다른 주소를 기본 배송지로 설정
     * 4. 이후 다시 기본 배송지였던 기존 주소 삭제 시도 가능
     * -> 비즈니스 연속성과 사용자 경험 최적화(실수 방지 등)
     */
     
커밋 5 4162a7cb2ea18ce800af0bb010961b3f43368a17 : User 엔티티에 defaultAddressId 필드가 있는게 옳지 않다고 생각해서 CustomerProfile 엔티티로 옮겼고, 그에 맞게 리팩토링을 했습니다. 
+ 배송지를 추가할 때 만약에 기본 배송지가 없는 상황(처음으로 배송지를 추가)이라면 기본 배송지로 설정되도록 수정하였습니다.

커밋 6 a180d1b0cadf8e9a61453fbac5c212e6425db5b4 : defaultAddressId 필드 위치 이동에 따른 추가 리팩토링을 진행했습니다.

커밋 7 0f62d5e9f220b8e79583cd8771104b2f5babd07e : 리팩토링 과정에서 User 엔티티에서 필요없는 메서드를 발견해 삭제했습니다.

커밋 8 bceaee5126f31d9bf5250e33c17ff56915700bf9 : Customer의 기본 배송지 ID 조회, 배송지 개수 조회, 배송지가 기본 배송지인지 확인하는 기능을 구현했습니다. 