### PR TITLE
feat(be): SellerProfileService 구현

### DIFF
--- a/backend/src/main/java/com/deliveranything/domain/user/client/StoreClient.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/client/StoreClient.java
@@ -1,0 +1,56 @@
+package com.deliveranything.domain.user.client;
+
+import com.deliveranything.domain.store.store.dto.StoreCreateRequest;
+import com.deliveranything.domain.store.store.enums.StoreCategoryType;
+import com.deliveranything.domain.store.store.service.StoreService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/***
+ * 웹서퍼 멘토님 조언대로 Client 구현 방식을 통해 다른 도메인 서비스코드와 연동해봤습니다.
+ ***/
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StoreClient {
+
+  private final StoreService storeService;
+
+  // 판매자용 기본 상점 생성
+  public Long createStoreForSeller(Long sellerProfileId, String businessName) {
+    try {
+      // Record 생성자 직접 사용
+      StoreCreateRequest request = new StoreCreateRequest(
+          StoreCategoryType.FOOD_CAFE,    // 음식/카페로 변경
+          businessName,
+          "미설정",
+          37.5665,
+          126.9780,
+          "{}"
+      );
+
+      /*** 기존 StoreService 메서드 호출
+       * StoreService의 createStore에 sellerProfileId 파라미터만 추가하면 바로 연동!
+       ***/
+      // Long storeId = storeService.createStore(sellerProfileId, request);
+      Long storeId = storeService.createStore(request); //
+      log.info("판매자용 상점 생성 성공: sellerProfileId={}, storeId={}", sellerProfileId, storeId);
+      return storeId;
+
+    } catch (Exception e) {
+      log.error("판매자용 상점 생성 실패: sellerProfileId={}", sellerProfileId, e);
+      return null; // 실패해도 SellerProfile 생성은 유지
+    }
+  }
+
+  // 판매자가 상점을 소유하고 있는지 확인 - 필요해 질 시 hasStore 요청
+//  public boolean hasStore(Long sellerProfileId) {
+//    try {
+//      return storeService.hasStore(sellerProfileId);
+//    } catch (Exception e) {
+//      log.error("상점 존재 여부 확인 실패: sellerProfileId={}", sellerProfileId, e);
+//      return false;
+//    }
+//  }
+}

--- a/backend/src/main/java/com/deliveranything/domain/user/client/StoreClient.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/client/StoreClient.java
@@ -18,7 +18,8 @@ public class StoreClient {
   private final StoreService storeService;
 
   // 판매자용 기본 상점 생성
-  public Long createStoreForSeller(Long sellerProfileId, String businessName) {
+  public Long createStoreForSeller(Long sellerProfileId,
+      String businessName) { // businessName : 상점 이름
     try {
       // Record 생성자 직접 사용
       StoreCreateRequest request = new StoreCreateRequest(
@@ -28,7 +29,7 @@ public class StoreClient {
           37.5665,
           126.9780,
           "{}"
-      );
+      ); // 기본 위치(서울)로 설정, 필요시 수정 가능
 
       /*** 기존 StoreService 메서드 호출
        * StoreService의 createStore에 sellerProfileId 파라미터만 추가하면 바로 연동!

--- a/backend/src/main/java/com/deliveranything/domain/user/entity/User.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package com.deliveranything.domain.user.entity;
 
 import com.deliveranything.domain.user.entity.profile.CustomerProfile;
 import com.deliveranything.domain.user.entity.profile.RiderProfile;
+import com.deliveranything.domain.user.entity.profile.SellerProfile;
 import com.deliveranything.domain.user.enums.ProfileType;
 import com.deliveranything.domain.user.enums.SocialProvider;
 import com.deliveranything.global.entity.BaseEntity;
@@ -11,7 +12,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
@@ -70,8 +70,10 @@ public class User extends BaseEntity {
   @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
   private CustomerProfile customerProfile;
 
-  @OneToOne(cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-  @JoinColumn(name = "rider_profile_id")
+  @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+  private SellerProfile sellerProfile;
+
+  @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
   private RiderProfile riderProfile;
 
   @Builder
@@ -106,7 +108,18 @@ public class User extends BaseEntity {
   }
 
   public void switchProfile(ProfileType targetProfile) {
+    if (!hasProfileForType(targetProfile)) {
+      throw new IllegalStateException(targetProfile + " 프로필이 존재하지 않습니다");
+    }
     this.currentActiveProfile = targetProfile;
+  }
+
+  private boolean hasProfileForType(ProfileType profileType) {
+    return switch (profileType) {
+      case CUSTOMER -> hasCustomerProfile();
+      case SELLER -> hasSellerProfile();
+      case RIDER -> hasRiderProfile();
+    };
   }
 
   public void enable() {
@@ -115,6 +128,18 @@ public class User extends BaseEntity {
 
   public void disable() {
     this.isEnabled = false;
+  }
+
+  public boolean hasCustomerProfile() {
+    return customerProfile != null;
+  }
+
+  public boolean hasSellerProfile() {
+    return sellerProfile != null;
+  }
+
+  public boolean hasRiderProfile() {
+    return riderProfile != null;
   }
 
   //테스트용 임시 세터 메서드.

--- a/backend/src/main/java/com/deliveranything/domain/user/entity/address/CustomerAddress.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/entity/address/CustomerAddress.java
@@ -2,6 +2,7 @@ package com.deliveranything.domain.user.entity.address;
 
 import com.deliveranything.domain.user.entity.profile.CustomerProfile;
 import com.deliveranything.global.entity.BaseEntity;
+import com.deliveranything.global.util.PointUtil;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -12,6 +13,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
 
 @Entity
 @Table(name = "customer_addresses")
@@ -29,11 +31,9 @@ public class CustomerAddress extends BaseEntity {
   @Column(nullable = false, length = 100)
   private String address;
 
-  @Column(precision = 10, scale = 7) // 10 , 7  값에 대해서는 협의 필요 (위도 경도 범위)
-  private Double latitude;
-
-  @Column(precision = 10, scale = 7)
-  private Double longitude;
+  // 위도 경도를 변경 Point 객체로 변경
+  @Column(columnDefinition = "POINT SRID 4326")
+  private Point location;
 
   @Builder
   public CustomerAddress(CustomerProfile customerProfile, String addressName,
@@ -42,8 +42,8 @@ public class CustomerAddress extends BaseEntity {
     this.customerProfile = customerProfile;
     this.addressName = addressName;
     this.address = address;
-    this.latitude = latitude;
-    this.longitude = longitude;
+    // 위도/경도를 받아서 Point 객체로 변환
+    this.location = PointUtil.createPoint(latitude, longitude);
   }
 
   // 비즈니스 메서드
@@ -56,7 +56,17 @@ public class CustomerAddress extends BaseEntity {
       Double latitude, Double longitude) {
     this.addressName = addressName;
     this.address = address;
-    this.latitude = latitude;
-    this.longitude = longitude;
+    // 위도/경도를 Point 객체로 변환
+    this.location = PointUtil.createPoint(latitude, longitude);
+
+  }
+
+  // 편의 메서드: 위도/경도 개별 접근
+  public Double getLatitude() {
+    return location != null ? location.getY() : null;
+  }
+
+  public Double getLongitude() {
+    return location != null ? location.getX() : null;
   }
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/repository/SellerProfileRepository.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/repository/SellerProfileRepository.java
@@ -4,6 +4,7 @@ import com.deliveranything.domain.user.entity.profile.SellerProfile;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository

--- a/backend/src/main/java/com/deliveranything/domain/user/repository/SellerProfileRepository.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/repository/SellerProfileRepository.java
@@ -6,5 +6,6 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SellerProfileRepository extends JpaRepository<SellerProfile, Long> {
-  
+
+  boolean existsByBusinessCertificateNumber(String businessCertificateNumber);
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/repository/SellerProfileRepository.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/repository/SellerProfileRepository.java
@@ -1,11 +1,18 @@
 package com.deliveranything.domain.user.repository;
 
 import com.deliveranything.domain.user.entity.profile.SellerProfile;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface SellerProfileRepository extends JpaRepository<SellerProfile, Long> {
 
   boolean existsByBusinessCertificateNumber(String businessCertificateNumber);
+
+  Optional<SellerProfile> findByBusinessCertificateNumber(String businessCertificateNumber);
+
+  @Query("SELECT sp FROM SellerProfile sp WHERE sp.user.id = :userId")
+  Optional<SellerProfile> findByUserId(@Param("userId") Long userId);
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/service/CustomerProfileService.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/service/CustomerProfileService.java
@@ -74,7 +74,7 @@ public class CustomerProfileService {
     if (user == null) {
       return false;
     }
-    return user.getCustomerProfile() != null;
+    return user.hasCustomerProfile();
   }
 
   // 고객 프로필 수정

--- a/backend/src/main/java/com/deliveranything/domain/user/service/SellerProfileService.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/service/SellerProfileService.java
@@ -1,0 +1,19 @@
+package com.deliveranything.domain.user.service;
+
+
+import com.deliveranything.domain.user.repository.SellerProfileRepository;
+import com.deliveranything.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SellerProfileService {
+
+  private final UserRepository userRepository;
+  private final SellerProfileRepository sellerProfileRepository;
+}

--- a/backend/src/main/java/com/deliveranything/domain/user/service/SellerProfileService.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/service/SellerProfileService.java
@@ -1,6 +1,9 @@
 package com.deliveranything.domain.user.service;
 
 
+import com.deliveranything.domain.user.client.StoreClient;
+import com.deliveranything.domain.user.entity.User;
+import com.deliveranything.domain.user.entity.profile.SellerProfile;
 import com.deliveranything.domain.user.repository.SellerProfileRepository;
 import com.deliveranything.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,4 +19,59 @@ public class SellerProfileService {
 
   private final UserRepository userRepository;
   private final SellerProfileRepository sellerProfileRepository;
+  private final StoreClient storeClient; // 외부 서비스와 통신하는 클라이언트
+
+  // 판매자 프로필 관리
+
+  // 판매자 프로필 생성 (UserService에서 온보딩 시 호출 예정)
+  @Transactional
+  public SellerProfile createProfile(Long userId, String nickname, String businessName,
+      String businessCertificateNumber, String businessPhoneNumber,
+      String bankName, String accountNumber, String accountHolder) {
+
+    // 사용자 존재 여부 확인
+    User user = userRepository.findById(userId).orElse(null);
+    if (user == null) {
+      log.warn("사용자를 찾을 수 없습니다: userId={}", userId);
+      return null;
+    }
+
+    // 이미 판매자 프로필이 존재하는지 여부 확인
+    if (user.getSellerProfile() != null) {
+      log.warn("이미 판매자 프로필이 존재합니다: userId={}", userId);
+      return user.getSellerProfile();
+    }
+
+    // 사업자 등록번호 중복 체크
+    if (sellerProfileRepository.existsByBusinessCertificateNumber(businessCertificateNumber)) {
+      log.warn("이미 존재하는 사업자 등록번호입니다: businessCertificateNumber={}", businessCertificateNumber);
+      return null;
+    }
+
+    SellerProfile sellerProfile = SellerProfile.builder()
+        .user(user)
+        .nickname(nickname)
+        .profileImageUrl(null)  // 기본값
+        .businessName(businessName)
+        .businessCertificateNumber(businessCertificateNumber)
+        .businessPhoneNumber(businessPhoneNumber)
+        .bankName(bankName)
+        .accountNumber(accountNumber)
+        .accountHolder(accountHolder)
+        .build();
+
+    sellerProfileRepository.save(sellerProfile);
+    log.info("판매자 프로필 생성 완료: userId={}, profileId={}", userId, sellerProfile.getId());
+
+    // 프로필 생성과 동시에 StoreClient를 통한 상점 자동 생성
+    Long storeId = storeClient.createStoreForSeller(sellerProfile.getId(), businessName);
+    if (storeId != null) {
+      log.info("판매자용 상점 생성 완료: sellerId={}, storeId={}", sellerProfile.getId(), storeId);
+    } else {
+      log.warn("판매자용 상점 생성 실패: sellerId={}", sellerProfile.getId());
+      // 상점 생성 실패해도 SellerProfile은 유지
+    }
+
+    return sellerProfile;
+  }
 }

--- a/backend/src/main/java/com/deliveranything/domain/user/service/SellerProfileService.java
+++ b/backend/src/main/java/com/deliveranything/domain/user/service/SellerProfileService.java
@@ -74,4 +74,77 @@ public class SellerProfileService {
 
     return sellerProfile;
   }
+
+  // 판매자 프로필 조회
+  public SellerProfile getProfile(Long userId) {
+    return sellerProfileRepository.findByUserId(userId).orElse(null);
+  }
+
+  // 판매자 프로필 존재 여부 확인
+  public boolean hasProfile(Long userId) {
+    return sellerProfileRepository.findByUserId(userId).isPresent();
+  }
+
+  // id로 판매자 프로필 존재여부 확인
+  public boolean existsById(Long sellerProfileId) {
+    return sellerProfileRepository.existsById(sellerProfileId);
+  }
+
+  // 판매자 프로필 수정
+  @Transactional
+  public boolean updateProfile(Long userId, String nickname, String profileImageUrl) {
+    SellerProfile profile = getProfile(userId);
+    if (profile == null) {
+      return false;
+    }
+
+    profile.updateProfile(nickname, profileImageUrl);
+    sellerProfileRepository.save(profile);
+
+    log.info("판매자 프로필 수정 완료: userId={}, nickname={}", userId, nickname);
+    return true;
+  }
+
+  // 사업자 정보 수정
+  @Transactional
+  public boolean updateBusinessInfo(Long userId, String businessName, String businessPhoneNumber) {
+    SellerProfile profile = getProfile(userId);
+    if (profile == null) {
+      return false;
+    }
+
+    profile.updateBusinessInfo(businessName, businessPhoneNumber);
+    sellerProfileRepository.save(profile);
+
+    log.info("사업자 정보 수정 완료: userId={}, businessName={}", userId, businessName);
+    return true;
+  }
+
+  // 정산 정보 수정
+  @Transactional
+  public boolean updateBankInfo(Long userId, String bankName, String accountNumber,
+      String accountHolder) {
+    SellerProfile profile = getProfile(userId);
+    if (profile == null) {
+      return false;
+    }
+
+    profile.updateBankInfo(bankName, accountNumber, accountHolder);
+    sellerProfileRepository.save(profile);
+
+    log.info("정산 정보 수정 완료: userId={}, bankName={}", userId, bankName);
+    return true;
+  }
+
+  // 사업자 등록번호 중복 체크
+  public boolean existsByBusinessCertificateNumber(String businessCertificateNumber) {
+    return sellerProfileRepository.existsByBusinessCertificateNumber(businessCertificateNumber);
+  }
+
+  // 사업자 등록번호로 판매자 프로필 조회
+  public SellerProfile getProfileByBusinessCertificateNumber(String businessCertificateNumber) {
+    return sellerProfileRepository.findByBusinessCertificateNumber(businessCertificateNumber)
+        .orElse(null);
+  }
+
 }


### PR DESCRIPTION
커밋 1 f77aec4908a4b6f4047bd88dd1df233a09f2616e : 
SellerProfileService에서 Store 도메인의 기능을 사용하고 연동할 필요가 있었습니다. 
- 이를 구현할 때 멘토님의 조언대로 도메인 경계를 명확히하고 단일 책임을 지게 하기 위해서 StoreClient 라는 이름의 Repository Layer (?) 를 생성했습니다.

커밋 2 55bff02048ae7b5a6f42a92758476605b1197882 :
SellerProfileService에 SellerProfile을 생성할 때 Store도 하나 생성되도록 연동하는 로직을 구현했습니다.

커밋 3 9da29fb18bfa745ab9f8536a973dafbd1fa004b6 :
SellerProfileService를 완성했습니다.
이제 UserService에 유저가 회원 가입 후 만나는 온보딩에서 프로필을 선택하면 해당 프로필을 생성하도록 로직을 구현했습니다.

커밋 4 b73574d79d85e92c03f367c4da50a150e84bcc80 :
Store의 위도 경도 사양에 맞게 CustomerAddress도 Point 객체를 이용하도록 리팩토링 했습니다. 