### PR TITLE
feat(be): 상점 도메인에서 필요로하는 주문 비즈니스 로직 추가

### DIFF
--- a/backend/src/main/java/com/deliveranything/domain/order/controller/OrderController.java
+++ b/backend/src/main/java/com/deliveranything/domain/order/controller/OrderController.java
@@ -46,7 +46,7 @@ public class OrderController {
       @RequestParam(defaultValue = "10") int size
   ) {
     return ResponseEntity.ok().body(ApiResponse.success("소비자 전체 주문 내역 조회 성공",
-        orderService.getCustomerOrders(인증 객체의 소비자 ID, cursor, size)));
+        orderService.getCustomerOrdersByCursor(인증 객체의 소비자 ID, cursor, size)));
   }
 
   @GetMapping("/{orderId}")

--- a/backend/src/main/java/com/deliveranything/domain/order/enums/OrderStatus.java
+++ b/backend/src/main/java/com/deliveranything/domain/order/enums/OrderStatus.java
@@ -6,15 +6,16 @@ public enum OrderStatus {
   RIDER_ASSIGNED,
   DELIVERING,
   COMPLETED,
+  REJECTED,
   CANCELLED;
 
   public boolean canTransitTo(OrderStatus next) {
     return switch (this) {
-      case PENDING -> next == PREPARING || next == CANCELLED;
+      case PENDING -> next == PREPARING || next == REJECTED || next == CANCELLED;
       case PREPARING -> next == RIDER_ASSIGNED;
       case RIDER_ASSIGNED -> next == DELIVERING;
       case DELIVERING -> next == COMPLETED;
-      case COMPLETED, CANCELLED -> false;
+      case COMPLETED, REJECTED, CANCELLED -> false;
     };
   }
 }

--- a/backend/src/main/java/com/deliveranything/domain/order/repository/OrderRepository.java
+++ b/backend/src/main/java/com/deliveranything/domain/order/repository/OrderRepository.java
@@ -17,4 +17,6 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
   List<Order> findByStatus(OrderStatus orderStatus);
 
   List<Order> findByDeliveryRiderProfileId(Long riderProfileId);
+
+  List<Order> findByStoreIdAndStatusInOrderByCreatedAtAsc(Long storeId, List<OrderStatus> statuses);
 }

--- a/backend/src/main/java/com/deliveranything/domain/order/repository/OrderRepositoryCustom.java
+++ b/backend/src/main/java/com/deliveranything/domain/order/repository/OrderRepositoryCustom.java
@@ -2,7 +2,10 @@ package com.deliveranything.domain.order.repository;
 
 import com.deliveranything.domain.order.entity.Order;
 import com.deliveranything.domain.order.entity.QOrder;
+import com.deliveranything.domain.order.enums.OrderStatus;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -24,5 +27,38 @@ public class OrderRepositoryCustom {
         .orderBy(order.id.desc())
         .limit(size)
         .fetch();
+  }
+
+  public List<Order> findStoreOrders(Long storeId, List<OrderStatus> statuses,
+      LocalDateTime lastCreatedAt, Long lastOrderId, int size) {
+    QOrder order = QOrder.order;
+
+    return queryFactory.selectFrom(order)
+        .where(
+            order.store.id.eq(storeId),
+            statusIn(statuses),
+            storeCursorCondition(lastCreatedAt, lastOrderId)
+        )
+        .orderBy(order.createdAt.desc(), order.id.desc())
+        .limit(size)
+        .fetch();
+  }
+
+  private BooleanExpression statusIn(List<OrderStatus> statuses) {
+    return statuses != null && !statuses.isEmpty() ? QOrder.order.status.in(statuses) : null;
+  }
+
+  // 최신순 커서
+  private BooleanExpression storeCursorCondition(LocalDateTime lastCreatedAt, Long lastOrderId) {
+    // 첫 페이지 조회 시 커서 조건 없음
+    if (lastCreatedAt == null || lastOrderId == null) {
+      return null;
+    }
+
+    QOrder order = QOrder.order;
+
+    // 1. 생성 시간 비교 2. 주문 ID 비교
+    return order.createdAt.lt(lastCreatedAt)
+        .or(order.createdAt.eq(lastCreatedAt).and(order.id.lt(lastOrderId)));
   }
 }

--- a/backend/src/main/java/com/deliveranything/domain/order/service/OrderService.java
+++ b/backend/src/main/java/com/deliveranything/domain/order/service/OrderService.java
@@ -15,6 +15,7 @@ import com.deliveranything.domain.user.service.CustomerProfileService;
 import com.deliveranything.global.common.CursorPageResponse;
 import com.deliveranything.global.exception.CustomException;
 import com.deliveranything.global.exception.ErrorCode;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -62,7 +63,7 @@ public class OrderService {
   }
 
   @Transactional(readOnly = true)
-  public CursorPageResponse<OrderResponse> getCustomerOrders(
+  public CursorPageResponse<OrderResponse> getCustomerOrdersByCursor(
       Long customerId,
       Long cursor,
       int size
@@ -77,7 +78,7 @@ public class OrderService {
 
     return new CursorPageResponse<>(
         orderResponses,
-        hasNext ? orderResponses.getLast().orderId().toString() : null,
+        hasNext ? orderResponses.getLast().id().toString() : null,
         hasNext
     );
   }
@@ -113,6 +114,23 @@ public class OrderService {
   public Order getOrderByMerchantId(String merchantId) {
     return orderRepository.findByMerchantId(merchantId)
         .orElseThrow(() -> new CustomException(ErrorCode.ORDER_NOT_FOUND));
+  }
+
+  @Transactional(readOnly = true)
+  public List<Order> getStoreOrdersWithStatuses(Long storeId, List<OrderStatus> orderStatuses) {
+    return orderRepository.findByStoreIdAndStatusInOrderByCreatedAtAsc(storeId, orderStatuses);
+  }
+
+  @Transactional(readOnly = true)
+  public List<Order> getStoreOrdersByCursor(
+      Long storeId,
+      List<OrderStatus> orderStatuses,
+      LocalDateTime lastCreatedAt,
+      Long lastOrderId,
+      int size
+  ) {
+    return orderRepositoryCustom.findStoreOrders(storeId, orderStatuses, lastCreatedAt, lastOrderId,
+        size + 1);
   }
 
   private Order getOrderById(Long orderId) {

--- a/backend/src/main/java/com/deliveranything/domain/store/store/dto/StoreFinalizedOrderResponse.java
+++ b/backend/src/main/java/com/deliveranything/domain/store/store/dto/StoreFinalizedOrderResponse.java
@@ -1,38 +1,27 @@
-package com.deliveranything.domain.order.dto;
+package com.deliveranything.domain.store.store.dto;
 
 import com.deliveranything.domain.order.entity.Order;
 import com.deliveranything.domain.order.entity.OrderItem;
 import com.deliveranything.domain.order.enums.OrderStatus;
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record OrderResponse(
-    Long id,
+public record StoreFinalizedOrderResponse(
+    Long orderId,
     List<OrderItem> orderItems,
     OrderStatus status,
-    String merchantId,
     String address,
-    String riderNote,
     String storeNote,
-    BigDecimal totalPrice,
-    BigDecimal storePrice,
-    BigDecimal deliveryPrice,
     LocalDateTime createdAt
 ) {
 
-  public static OrderResponse from(Order order) {
-    return new OrderResponse(
+  public static StoreFinalizedOrderResponse from(Order order) {
+    return new StoreFinalizedOrderResponse(
         order.getId(),
         order.getOrderItems(),
         order.getStatus(),
-        order.getMerchantId(),
         order.getAddress(),
-        order.getRiderNote(),
         order.getStoreNote(),
-        order.getTotalPrice(),
-        order.getStorePrice(),
-        order.getDeliveryPrice(),
         order.getCreatedAt()
     );
   }


### PR DESCRIPTION
SSE 관련 코드는 추후 구현 예정
★★★영빈님 꼭 보셔야 합니다★★★

상점/상품
최신순(내림차순 - 이력 조회만, 나머지는 오름차순) & 커서(이력 조회만)

메인 페이지에서 자기 가게에 대한 주문 리스트 반환(주문 수락 탭)
=> PENDING  // 전체 리스트 + SSE
=> getStoreOrdersWithStatus, 새 주문은 SSE로 업데이트

메인 페이지에서 자기 가게에 대한 주문 리스트 반환(주문 현황 탭)
=> PREPAIRING, RIDER_ASSIGNED, DELIVERING // 전체 리스트 + SSE
=> getStoreOrdersWithStatus, 배달 완료 된 주문 SSE로 업데이트(주문 현황 탭에서 제거)

주문 이력 조회 페이지에서 자기 가게에 대한 주문 리스트 반환
=> COMPLETED, REJECTED // 전체 리스트 + 커서 + SSE 
이건 SSE로 배달 완료 알림을 받으니까 "새로고침하라고 새로운 배달 완료건이 있습니다." 보고 사용자 선택으로 화면 새로고침