### PR TITLE
refactor(be): 주문 도메인 엔티티 저장 방식 및 관련 코드 개선

### DIFF
--- a/backend/src/main/java/com/deliveranything/domain/order/controller/CustomerOrderController.java
+++ b/backend/src/main/java/com/deliveranything/domain/order/controller/CustomerOrderController.java
@@ -30,6 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/customer/orders")
 @RestController
 @Tag(name = "고객 주문 API", description = "소비자의 주문처리 관련 API입니다.")
+@PreAuthorize("@profileSecurity.isCustomer(authentication.principal)")
 public class CustomerOrderController {
 
   private final CustomerOrderService customerOrderService;
@@ -37,7 +38,6 @@ public class CustomerOrderController {
 
   @PostMapping
   @Operation(summary = "주문 생성", description = "소비자가 상점에 주문을 요청한 경우")
-  @PreAuthorize("@profileSecurity.isCustomer(#securityUser)")
   public ResponseEntity<ApiResponse<OrderCreateResponse>> create(
       @AuthenticationPrincipal SecurityUser securityUser,
       @Valid @RequestBody OrderCreateRequest orderCreateRequest
@@ -49,7 +49,6 @@ public class CustomerOrderController {
 
   @GetMapping
   @Operation(summary = "주문 내역 조회", description = "소비자가 주문 내역을 요청한 경우")
-  @PreAuthorize("@profileSecurity.isCustomer(#securityUser)")
   public ResponseEntity<ApiResponse<CursorPageResponse<OrderResponse>>> getAll(
       @AuthenticationPrincipal SecurityUser securityUser,
       @RequestParam(required = false) String nextPageToken,
@@ -62,7 +61,6 @@ public class CustomerOrderController {
 
   @GetMapping("/{orderId}")
   @Operation(summary = "주문 단일 조회", description = "소비자가 어떤 주문의 상세 정보를 요청한 경우")
-  @PreAuthorize("@profileSecurity.isCustomer(#securityUser)")
   public ResponseEntity<ApiResponse<OrderResponse>> get(
       @AuthenticationPrincipal SecurityUser securityUser,
       @PathVariable Long orderId
@@ -74,7 +72,6 @@ public class CustomerOrderController {
 
   @GetMapping("/in-progress")
   @Operation(summary = "진행중인 주문 조회", description = "소비자가 진행중인 주문 내역을 요청한 경우")
-  @PreAuthorize("@profileSecurity.isCustomer(#securityUser)")
   public ResponseEntity<ApiResponse<List<OrderResponse>>> getInProgressOrders(
       @AuthenticationPrincipal SecurityUser securityUser
   ) {
@@ -84,7 +81,6 @@ public class CustomerOrderController {
 
   @GetMapping("/completed")
   @Operation(summary = "배달 완료된 주문 조회", description = "소비자가 배달 완료된 주문 내역을 요청한 경우")
-  @PreAuthorize("@profileSecurity.isCustomer(#securityUser)")
   public ResponseEntity<ApiResponse<CursorPageResponse<OrderResponse>>> getCompletedOrders(
       @AuthenticationPrincipal SecurityUser securityUser,
       @RequestParam(required = false) String nextPageToken,
@@ -97,9 +93,7 @@ public class CustomerOrderController {
 
   @PostMapping("/{merchantUid}/pay")
   @Operation(summary = "주문 결제", description = "소비자가 생성한 주문의 결제 시도")
-  @PreAuthorize("@profileSecurity.isCustomer(#securityUser)")
   public ResponseEntity<ApiResponse<String>> pay(
-      @AuthenticationPrincipal SecurityUser securityUser,
       @PathVariable String merchantUid,
       @Valid @RequestBody OrderPayRequest orderPayRequest
   ) {
@@ -109,9 +103,7 @@ public class CustomerOrderController {
 
   @PostMapping("/{orderId}/cancel")
   @Operation(summary = "주문 취소", description = "소비자가 상점에서 주문 수락 전인 주문을 취소하는 경우")
-  @PreAuthorize("@profileSecurity.isCustomer(#securityUser)")
   public ResponseEntity<ApiResponse<String>> cancel(
-      @AuthenticationPrincipal SecurityUser securityUser,
       @PathVariable Long orderId,
       @RequestBody OrderCancelRequest orderCancelRequest
   ) {

--- a/backend/src/main/java/com/deliveranything/domain/order/controller/CustomerOrderController.java
+++ b/backend/src/main/java/com/deliveranything/domain/order/controller/CustomerOrderController.java
@@ -52,7 +52,7 @@ public class CustomerOrderController {
   public ResponseEntity<ApiResponse<CursorPageResponse<OrderResponse>>> getAll(
       @AuthenticationPrincipal SecurityUser securityUser,
       @RequestParam(required = false) String nextPageToken,
-      @RequestParam(defaultValue = "10") int size
+      @RequestParam(defaultValue = "10") long size
   ) {
     return ResponseEntity.ok().body(ApiResponse.success("소비자 전체 주문 내역 조회 성공",
         customerOrderService.getCustomerOrdersByCursor(securityUser.getCurrentActiveProfileIdSafe(),
@@ -84,7 +84,7 @@ public class CustomerOrderController {
   public ResponseEntity<ApiResponse<CursorPageResponse<OrderResponse>>> getCompletedOrders(
       @AuthenticationPrincipal SecurityUser securityUser,
       @RequestParam(required = false) String nextPageToken,
-      @RequestParam(defaultValue = "10") int size
+      @RequestParam(defaultValue = "10") long size
   ) {
     return ResponseEntity.ok().body(ApiResponse.success("배달 완료된 소비자 주문 조회 성공",
         customerOrderService.getCompletedOrdersByCursor(

--- a/backend/src/main/java/com/deliveranything/domain/order/controller/CustomerOrderController.java
+++ b/backend/src/main/java/com/deliveranything/domain/order/controller/CustomerOrderController.java
@@ -42,7 +42,6 @@ public class CustomerOrderController {
       @AuthenticationPrincipal SecurityUser securityUser,
       @Valid @RequestBody OrderCreateRequest orderCreateRequest
   ) {
-
     return ResponseEntity.ok().body(ApiResponse.success("주문이 접수되어 처리중입니다.",
         customerOrderService.createOrder(securityUser.getCurrentActiveProfileIdSafe(),
             orderCreateRequest)));
@@ -53,12 +52,12 @@ public class CustomerOrderController {
   @PreAuthorize("@profileSecurity.isCustomer(#securityUser)")
   public ResponseEntity<ApiResponse<CursorPageResponse<OrderResponse>>> getAll(
       @AuthenticationPrincipal SecurityUser securityUser,
-      @RequestParam(required = false) Long cursor,
+      @RequestParam(required = false) String nextPageToken,
       @RequestParam(defaultValue = "10") int size
   ) {
     return ResponseEntity.ok().body(ApiResponse.success("소비자 전체 주문 내역 조회 성공",
         customerOrderService.getCustomerOrdersByCursor(securityUser.getCurrentActiveProfileIdSafe(),
-            cursor, size)));
+            nextPageToken, size)));
   }
 
   @GetMapping("/{orderId}")

--- a/backend/src/main/java/com/deliveranything/domain/order/dto/OrderCreateRequest.java
+++ b/backend/src/main/java/com/deliveranything/domain/order/dto/OrderCreateRequest.java
@@ -1,5 +1,9 @@
 package com.deliveranything.domain.order.dto;
 
+import com.deliveranything.domain.order.entity.Order;
+import com.deliveranything.domain.store.store.entity.Store;
+import com.deliveranything.domain.user.profile.entity.CustomerProfile;
+import com.deliveranything.global.util.PointUtil;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
@@ -21,4 +25,17 @@ public record OrderCreateRequest(
     @NotNull @Positive Long deliveryPrice
 ) {
 
+  public Order toEntity(CustomerProfile customerProfile, Store store) {
+    return Order.builder()
+        .customer(customerProfile)
+        .store(store)
+        .address(this.address)
+        .destination(PointUtil.createPoint(this.lat, this.lng))
+        .riderNote(this.riderNote)
+        .storeNote(this.storeNote)
+        .totalPrice(this.totalPrice)
+        .storePrice(this.storePrice)
+        .deliveryPrice(this.deliveryPrice)
+        .build();
+  }
 }

--- a/backend/src/main/java/com/deliveranything/domain/order/enums/OrderStatus.java
+++ b/backend/src/main/java/com/deliveranything/domain/order/enums/OrderStatus.java
@@ -1,5 +1,7 @@
 package com.deliveranything.domain.order.enums;
 
+import java.util.List;
+
 public enum OrderStatus {
   CREATED,
   PENDING,
@@ -12,6 +14,12 @@ public enum OrderStatus {
   CANCELLATION_REQUESTED,
   CANCEL_FAILED,
   PAYMENT_FAILED;
+
+  public static final List<OrderStatus> IN_PROGRESS_STATUSES = List.of(
+      PENDING, PREPARING, RIDER_ASSIGNED, DELIVERING
+  );
+
+  public static final List<OrderStatus> COMPLETED_STATUSES = List.of(COMPLETED);
 
   public boolean canTransitTo(OrderStatus next) {
     return switch (this) {

--- a/backend/src/main/java/com/deliveranything/domain/order/repository/OrderRepositoryCustom.java
+++ b/backend/src/main/java/com/deliveranything/domain/order/repository/OrderRepositoryCustom.java
@@ -17,7 +17,8 @@ public class OrderRepositoryCustom {
 
   private final JPAQueryFactory queryFactory;
 
-  public List<Order> findOrdersWithStoreByCustomerId(Long customerId, Long cursor, int size) {
+  public List<Order> findOrdersWithStoreByCustomerId(Long customerId, LocalDateTime lastCreatedAt,
+      Long lastOrderId, int size) {
     QOrder order = QOrder.order;
     QStore store = QStore.store;
 
@@ -25,9 +26,9 @@ public class OrderRepositoryCustom {
         .join(order.store, store).fetchJoin()
         .where(
             order.customer.id.eq(customerId),
-            cursor != null ? order.id.lt(cursor) : null
+            storeCursorCondition(lastCreatedAt, lastOrderId)
         )
-        .orderBy(order.id.desc())
+        .orderBy(order.createdAt.desc(), order.id.desc())
         .limit(size)
         .fetch();
   }

--- a/backend/src/main/java/com/deliveranything/domain/order/repository/OrderRepositoryCustom.java
+++ b/backend/src/main/java/com/deliveranything/domain/order/repository/OrderRepositoryCustom.java
@@ -17,51 +17,56 @@ public class OrderRepositoryCustom {
 
   private final JPAQueryFactory queryFactory;
 
-  public List<Order> findOrdersWithStoreByCustomerId(Long customerId, LocalDateTime lastCreatedAt,
-      Long lastOrderId, int size) {
-    QOrder order = QOrder.order;
-    QStore store = QStore.store;
-
-    return queryFactory.selectFrom(order)
-        .join(order.store, store).fetchJoin()
-        .where(
-            order.customer.id.eq(customerId),
-            storeCursorCondition(lastCreatedAt, lastOrderId)
-        )
-        .orderBy(order.createdAt.desc(), order.id.desc())
-        .limit(size)
-        .fetch();
+  public List<Order> findOrdersWithStoreByCustomerId(
+      Long customerId,
+      LocalDateTime lastCreatedAt,
+      Long lastOrderId,
+      long size
+  ) {
+    return fetchOrders(
+        size,
+        cursorCondition(lastCreatedAt, lastOrderId),
+        QOrder.order.customer.id.eq(customerId)
+    );
   }
 
-  public List<Order> findOrdersWithStoreByStoreId(Long storeId, List<OrderStatus> statuses,
-      LocalDateTime lastCreatedAt, Long lastOrderId, int size) {
-    QOrder order = QOrder.order;
-    QStore store = QStore.store;
-
-    return queryFactory.selectFrom(order)
-        .join(order.store, store).fetchJoin()
-        .where(
-            order.store.id.eq(storeId),
-            statusIn(statuses),
-            storeCursorCondition(lastCreatedAt, lastOrderId)
-        )
-        .orderBy(order.createdAt.desc(), order.id.desc())
-        .limit(size)
-        .fetch();
+  public List<Order> findOrdersWithStoreByStoreId(
+      Long storeId,
+      List<OrderStatus> statuses,
+      LocalDateTime lastCreatedAt,
+      Long lastOrderId,
+      long size
+  ) {
+    return fetchOrders(
+        size,
+        cursorCondition(lastCreatedAt, lastOrderId),
+        QOrder.order.store.id.eq(storeId),
+        statusIn(statuses)
+    );
   }
 
-  public List<Order> findOrdersWithStoreByCustomerId(Long customerId, List<OrderStatus> statuses,
-      LocalDateTime lastCreatedAt, Long lastOrderId, int size) {
+  public List<Order> findOrdersWithStoreByCustomerId(
+      Long customerId,
+      List<OrderStatus> statuses,
+      LocalDateTime lastCreatedAt,
+      Long lastOrderId,
+      long size
+  ) {
+    return fetchOrders(
+        size,
+        cursorCondition(lastCreatedAt, lastOrderId),
+        QOrder.order.customer.id.eq(customerId),
+        statusIn(statuses)
+    );
+  }
+
+  private List<Order> fetchOrders(long size, BooleanExpression... conditions) {
     QOrder order = QOrder.order;
     QStore store = QStore.store;
 
     return queryFactory.selectFrom(order)
         .join(order.store, store).fetchJoin()
-        .where(
-            order.customer.id.eq(customerId),
-            statusIn(statuses),
-            storeCursorCondition(lastCreatedAt, lastOrderId)
-        )
+        .where(conditions)
         .orderBy(order.createdAt.desc(), order.id.desc())
         .limit(size)
         .fetch();
@@ -72,7 +77,7 @@ public class OrderRepositoryCustom {
   }
 
   // 최신순 커서
-  private BooleanExpression storeCursorCondition(LocalDateTime lastCreatedAt, Long lastOrderId) {
+  private BooleanExpression cursorCondition(LocalDateTime lastCreatedAt, Long lastOrderId) {
     // 첫 페이지 조회 시 커서 조건 없음
     if (lastCreatedAt == null || lastOrderId == null) {
       return null;
@@ -80,7 +85,8 @@ public class OrderRepositoryCustom {
 
     QOrder order = QOrder.order;
 
-    // 1. 생성 시간 비교 2. 주문 ID 비교
+    // 1. 이전에 생성한 레코드 추출
+    // 2. 생성 시각이 같다면 주문 ID 작은 것들 추출
     return order.createdAt.lt(lastCreatedAt)
         .or(order.createdAt.eq(lastCreatedAt).and(order.id.lt(lastOrderId)));
   }

--- a/backend/src/main/java/com/deliveranything/domain/order/service/CustomerOrderService.java
+++ b/backend/src/main/java/com/deliveranything/domain/order/service/CustomerOrderService.java
@@ -11,13 +11,14 @@ import com.deliveranything.domain.order.event.OrderCreatedEvent;
 import com.deliveranything.domain.order.repository.OrderRepository;
 import com.deliveranything.domain.order.repository.OrderRepositoryCustom;
 import com.deliveranything.domain.product.product.service.ProductService;
+import com.deliveranything.domain.store.store.entity.Store;
 import com.deliveranything.domain.store.store.service.StoreService;
+import com.deliveranything.domain.user.profile.entity.CustomerProfile;
 import com.deliveranything.domain.user.profile.service.CustomerProfileService;
 import com.deliveranything.global.common.CursorPageResponse;
 import com.deliveranything.global.exception.CustomException;
 import com.deliveranything.global.exception.ErrorCode;
 import com.deliveranything.global.util.CursorUtil;
-import com.deliveranything.global.util.PointUtil;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Collections;
@@ -45,18 +46,10 @@ public class CustomerOrderService {
 
   @Transactional
   public OrderCreateResponse createOrder(Long customerId, OrderCreateRequest orderCreateRequest) {
-    Order order = Order.builder()
-        .customer(customerProfileService.getProfileByProfileId(customerId))
-        .store(storeService.getStoreById(orderCreateRequest.storeId()))
-        .address(orderCreateRequest.address())
-        .destination(PointUtil.createPoint(orderCreateRequest.lat(), orderCreateRequest.lng()))
-        .riderNote(orderCreateRequest.riderNote())
-        .storeNote(orderCreateRequest.storeNote())
-        .totalPrice(orderCreateRequest.totalPrice())
-        .storePrice(orderCreateRequest.storePrice())
-        .deliveryPrice(orderCreateRequest.deliveryPrice())
-        .build();
+    CustomerProfile customerProfile = customerProfileService.getProfileByProfileId(customerId);
+    Store store = storeService.getStoreById(orderCreateRequest.storeId());
 
+    Order order = orderCreateRequest.toEntity(customerProfile, store);
     for (OrderItemRequest orderItemRequest : orderCreateRequest.orderItemRequests()) {
       OrderItem orderItem = OrderItem.builder()
           .product(productService.getProductById(orderItemRequest.productId()))
@@ -68,7 +61,6 @@ public class CustomerOrderService {
     }
 
     Order savedOrder = orderRepository.save(order);
-
     eventPublisher.publishEvent(OrderCreatedEvent.from(savedOrder));
 
     return OrderCreateResponse.from(savedOrder);

--- a/backend/src/main/java/com/deliveranything/domain/order/service/CustomerOrderService.java
+++ b/backend/src/main/java/com/deliveranything/domain/order/service/CustomerOrderService.java
@@ -84,9 +84,8 @@ public class CustomerOrderService {
 
   @Transactional(readOnly = true)
   public List<OrderResponse> getProgressingOrders(Long customerId) {
-    return orderRepository.findOrdersWithStoreByCustomerIdAndStatuses(customerId, List.of(
-            OrderStatus.PENDING, OrderStatus.PREPARING, OrderStatus.RIDER_ASSIGNED,
-            OrderStatus.DELIVERING)).stream()
+    return orderRepository.findOrdersWithStoreByCustomerIdAndStatuses(customerId,
+            OrderStatus.IN_PROGRESS_STATUSES).stream()
         .map(OrderResponse::from)
         .toList();
   }
@@ -98,7 +97,7 @@ public class CustomerOrderService {
       int size
   ) {
     return getOrdersByCursorInternal(customerId, nextPageToken, size,
-        List.of(OrderStatus.COMPLETED));
+        OrderStatus.COMPLETED_STATUSES);
   }
 
   private CursorPageResponse<OrderResponse> getOrdersByCursorInternal(

--- a/backend/src/main/java/com/deliveranything/domain/order/service/CustomerOrderService.java
+++ b/backend/src/main/java/com/deliveranything/domain/order/service/CustomerOrderService.java
@@ -19,13 +19,17 @@ import com.deliveranything.global.exception.ErrorCode;
 import com.deliveranything.global.util.CursorUtil;
 import com.deliveranything.global.util.PointUtil;
 import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
+import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class CustomerOrderService {
@@ -73,29 +77,10 @@ public class CustomerOrderService {
   @Transactional(readOnly = true)
   public CursorPageResponse<OrderResponse> getCustomerOrdersByCursor(
       Long customerId,
-      Long cursor,
+      String nextPageToken,
       int size
   ) {
-    List<Order> orders = orderRepositoryCustom.findOrdersWithStoreByCustomerId(customerId, cursor,
-        size + 1);
-
-    List<OrderResponse> orderResponses = orders.stream()
-        .limit(size)
-        .map(OrderResponse::from)
-        .toList();
-
-    boolean hasNext = orders.size() > size;
-
-    try {
-      OrderResponse lastResponse = orderResponses.getLast();
-      return new CursorPageResponse<>(
-          orderResponses,
-          hasNext ? CursorUtil.encode(lastResponse.createdAt(), lastResponse.id()) : null,
-          hasNext
-      );
-    } catch (NoSuchElementException e) {
-      return new CursorPageResponse<>(orderResponses, null, hasNext);
-    }
+    return getOrdersByCursorInternal(customerId, nextPageToken, size, Collections.emptyList());
   }
 
   @Transactional(readOnly = true)
@@ -120,6 +105,16 @@ public class CustomerOrderService {
       String nextPageToken,
       int size
   ) {
+    return getOrdersByCursorInternal(customerId, nextPageToken, size,
+        List.of(OrderStatus.COMPLETED));
+  }
+
+  private CursorPageResponse<OrderResponse> getOrdersByCursorInternal(
+      Long customerId,
+      String nextPageToken,
+      int size,
+      List<OrderStatus> statuses
+  ) {
     LocalDateTime lastCreatedAt = null;
     Long lastOrderId = null;
     Object[] decodedParts = CursorUtil.decode(nextPageToken);
@@ -128,31 +123,38 @@ public class CustomerOrderService {
       try {
         lastCreatedAt = LocalDateTime.parse(decodedParts[0].toString());
         lastOrderId = Long.parseLong(decodedParts[1].toString());
+      } catch (DateTimeParseException e) {
+        log.warn("커서 토큰에서 날짜 파싱 실패", e);
       } catch (NumberFormatException e) {
-        lastCreatedAt = null;
-        lastOrderId = null;
+        log.warn("커서 토큰에서 주문ID 파싱 실패", e);
       }
     }
 
-    List<Order> cursorOrders = orderRepositoryCustom.findOrdersWithStoreByCustomerId(customerId,
-        List.of(OrderStatus.COMPLETED), lastCreatedAt, lastOrderId, size + 1);
+    List<Order> orders;
+    if (statuses == null || statuses.isEmpty()) {
+      orders = orderRepositoryCustom.findOrdersWithStoreByCustomerId(customerId,
+          lastCreatedAt, lastOrderId, size + 1);
+    } else {
+      orders = orderRepositoryCustom.findOrdersWithStoreByCustomerId(customerId,
+          statuses, lastCreatedAt, lastOrderId, size + 1);
+    }
 
-    List<OrderResponse> cursorResponses = cursorOrders.stream()
+    List<OrderResponse> orderResponses = orders.stream()
         .limit(size)
         .map(OrderResponse::from)
         .toList();
 
-    boolean hasNext = cursorOrders.size() > size;
+    boolean hasNext = orders.size() > size;
 
     try {
-      OrderResponse lastResponse = cursorResponses.getLast();
+      OrderResponse lastResponse = orderResponses.getLast();
       return new CursorPageResponse<>(
-          cursorResponses,
+          orderResponses,
           hasNext ? CursorUtil.encode(lastResponse.createdAt(), lastResponse.id()) : null,
           hasNext
       );
     } catch (NoSuchElementException e) {
-      return new CursorPageResponse<>(cursorResponses, null, hasNext);
+      return new CursorPageResponse<>(orderResponses, null, false);
     }
   }
 }

--- a/backend/src/main/java/com/deliveranything/domain/order/service/CustomerOrderService.java
+++ b/backend/src/main/java/com/deliveranything/domain/order/service/CustomerOrderService.java
@@ -70,7 +70,7 @@ public class CustomerOrderService {
   public CursorPageResponse<OrderResponse> getCustomerOrdersByCursor(
       Long customerId,
       String nextPageToken,
-      int size
+      long size
   ) {
     return getOrdersByCursorInternal(customerId, nextPageToken, size, Collections.emptyList());
   }
@@ -94,7 +94,7 @@ public class CustomerOrderService {
   public CursorPageResponse<OrderResponse> getCompletedOrdersByCursor(
       Long customerId,
       String nextPageToken,
-      int size
+      long size
   ) {
     return getOrdersByCursorInternal(customerId, nextPageToken, size,
         OrderStatus.COMPLETED_STATUSES);
@@ -103,7 +103,7 @@ public class CustomerOrderService {
   private CursorPageResponse<OrderResponse> getOrdersByCursorInternal(
       Long customerId,
       String nextPageToken,
-      int size,
+      long size,
       List<OrderStatus> statuses
   ) {
     LocalDateTime lastCreatedAt = null;
@@ -124,10 +124,10 @@ public class CustomerOrderService {
     List<Order> orders;
     if (statuses == null || statuses.isEmpty()) {
       orders = orderRepositoryCustom.findOrdersWithStoreByCustomerId(customerId,
-          lastCreatedAt, lastOrderId, size + 1);
+          lastCreatedAt, lastOrderId, size + 1L);
     } else {
       orders = orderRepositoryCustom.findOrdersWithStoreByCustomerId(customerId,
-          statuses, lastCreatedAt, lastOrderId, size + 1);
+          statuses, lastCreatedAt, lastOrderId, size + 1L);
     }
 
     List<OrderResponse> orderResponses = orders.stream()


### PR DESCRIPTION
주문 도메인
- 페이징 방식 encode/decode 방식으로 일원화
- 주문 생성 로직 중 일부 DTO로 위임 (단순 생성만 위임)
- 목록 Enum으로 코드 품질 개선(의미적 가독성)
- CustomerOrderController 클레스 레벨에서 신원 확인
- 커서 기반 조회 로직 개선(코드 중복 제거 및 가독성 개선)